### PR TITLE
Disable SChannel on Windows, enable OpenSSL

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -88,6 +88,8 @@ pkg-config --list-all
   --enable-muxers      \
   --enable-demuxers    \
   --enable-parsers     \
+  --enable-openssl     \
+  --disable-schannel   \
   --extra-cflags="-I${prefix}/include" \
   --extra-ldflags="-L${prefix}/lib"
 make -j${nproc}
@@ -150,7 +152,8 @@ dependencies = [
     "https://github.com/JuliaIO/x264Builder/releases/download/v2019.5.25-static/build_x264Builder.v2019.5.25.jl",
     "https://github.com/JuliaIO/x265Builder/releases/download/v3.0.0-static/build_x265Builder.v3.0.0.jl",
     "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Bzip2-v1.0.6-0/build_Bzip2.v1.0.6.jl",
-    "https://github.com/ianshmean/ZlibBuilder/releases/download/v1.2.11/build_Zlib.v1.2.11.jl"
+    "https://github.com/ianshmean/ZlibBuilder/releases/download/v1.2.11/build_Zlib.v1.2.11.jl",
+    "https://github.com/JuliaPackaging/Yggdrasil/releases/download/OpenSSL-v1.1.1%2Bc%2B0/build_OpenSSL.v1.1.1+c.jl",
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
This should address part of the issue at https://github.com/JuliaIO/FFMPEG.jl/issues/12.

The problem is the following: if openssl and gnutls are not used on Windows, SChannel is used instead to provide support for TLS.  However, this causes `avformat` to be linked to `Secur32.dll`, which is not always loaded by Julia on Windows (or it has a different capitalisation, like `secur32.dll`).  As shown in https://github.com/JuliaIO/FFMPEG.jl/issues/12#issuecomment-536943870, the official binaries use gnutls, however we don't have a builder for gnutls for Windows, so in this PR I'm using openssl.

However, while this PR makes `avformat` dlopen'able, I'm now having problems with `avdevice-58.dll` that cannot be dlopen'ed :persevere: 

CC: @SimonDanisch @ianshmean 